### PR TITLE
bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-base-build:1.0.0 AS patched
+FROM 416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-base-build:1.0.5 AS patched
 
 RUN dnf upgrade -y \
   && dnf update
 
 FROM patched AS builder
 
-ARG SHELLCHECK_VERSION=v0.9.0
+ARG SHELLCHECK_VERSION=v0.11.0
 
 # Pipefail handled via the exit
 # hadolint ignore=DL4006
 RUN arch="$(uname -m)" \
-  && dnf install -y tar-2:1.34 xz-5.2.5 \
+  && dnf install -y xz-5.2.5 \
   && url_base='https://github.com/koalaman/shellcheck/releases/download/' \
   && tar_file="${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.${arch}.tar.xz" \
   && { wget -q "${url_base}${tar_file}" -O - | tar xJf -; } || exit 1 \
@@ -23,9 +23,9 @@ COPY --from=builder /bin/shellcheck /bin/shellcheck
 COPY ./bin/* /opt/ci-shellcheck-task/bin/
 COPY ./lib/* /opt/ci-shellcheck-task/lib/
 
-RUN dnf install -y bash-5.2.15 make-4.3 findutils-1:4.8.0 file-5.39 && dnf clean all && chmod +x /opt/ci-shellcheck-task/bin/*
+RUN dnf install -y findutils-1:4.8.0 file-5.39 && dnf clean all && chmod +x /opt/ci-shellcheck-task/bin/*
 
-LABEL base.image="alpine:3.12" \
+LABEL base.image="ci-base-build:1.0.5" \
   repostory.name="ci-shellcheck-task"
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
Associated to the migration of the building pipeline to 
(shared-services)-Concourse:
https://github.com/companieshouse/ci-pipelines/pull/6966